### PR TITLE
Nix flake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ src/build
 *.user
 *.autosave
 .vscode
+result

--- a/README.md
+++ b/README.md
@@ -66,7 +66,18 @@ These instructions also apply to building the latest release version of Koi. Ins
 
 **Building with NIX**
 
-`nix-build -E 'with import <nixpkgs> {}; pkgs.libsForQt5.callPackage ./dev.nix {}'`
+There are to ways of building this project using NIX. The first is to use the legacy `nix-build` command together with the `dev.nix` file. The second is to use [nix flakes](https://nixos.wiki/wiki/Flakes), which are, as of the time of writing, still experimental.
+
+To use the legacy method, run the following command in the root of the project:
+
+```bash
+nix-build -E 'with import <nixpkgs> {}; pkgs.libsForQt5.callPackage ./dev.nix {}'
+```
+To build the project with flakes, run the following command in the root of the project:
+
+```bash
+nix build
+```
 
 ## Downloads
 
@@ -101,10 +112,42 @@ Available from [copr](https://copr.fedorainfracloud.org/coprs/birkch/Koi/). Pack
 
 ### NixOS and distros with nix.
 
-**Download**
+**NUR**
 
 Available from me [NUR](https://nur.nix-community.org/repos/baduhai/) repo. Packaged by yours truly.  
 Install to your NIX profile with `nix-env -iA koi -f https://github.com/baduhai/nur/tarball/master`, to add to you nixos configuration, follow the [Instructions](https://github.com/nix-community/nur#installation) on the NUR repo.
+
+**Nix Flake installation**
+
+If you have flakes enabled (see here for a guide and further information about what flakes are: [https://nixos.wiki/wiki/Flakes](https://nixos.wiki/wiki/Flakes)), you can add Koi to your system by adding this repository as an input to your `flake.nix`:
+
+```nix
+{
+  # 1. Add Koi as an input
+  # NOTE: After this PR has been merged, you may use the upstream repo `"github:baduhai/Koi";` instead.
+  inputs.koi.url = "github:Quoteme/Koi-custom-script";
+  # 2. Add the Koi-input to your outputs
+  outputs = { self, koi }: {
+    # ...
+    # 3. Add Koi to your `environment.systemPackages`!
+    environment.systemPackages = [
+      # ...
+    koi.defaultPackage.x86_64-linux
+    ]
+  };
+}
+```
+
+Then, you will have Koi installed after running `nixos-rebuild switch`.
+
+**Nix Flake shell**
+
+You can temporarily enter a Nix shell with Koi available, if you have flakes enabled, by running:
+
+```bash
+# NOTE: After this PR has been merged, you may use the upstream repo `github:baduhai/Koi` instead.
+nix shell github:quoteme/st-nix
+```
 
 ### Debian/Ubuntu
 

--- a/dev.nix
+++ b/dev.nix
@@ -6,12 +6,12 @@
 
 mkDerivation rec{
   name = "koi";
-  
+
   src = ./src;
 
   nativeBuildInputs = [ cmake ];
-  
+
   buildInputs = [ wrapQtAppsHook kcoreaddons kwidgetsaddons kconfig ];
-  
-  sourceRoot = "source/src";
+
+  # sourceRoot = "source/src";
 } 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1710734606,
+        "narHash": "sha256-rFJl+WXfksu2NkWJWKGd5Km17ZGEjFg9hOQNwstsoU8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "79bb4155141a5e68f2bdee2bf6af35b1d27d3a1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Koi - Theme scheduling for the KDE Plasma Desktop";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+      in
+      {
+        packages.default = pkgs.callPackage ./dev.nix {
+          # TODO: clearly I am too stupid to understand `callPackage` correctly. This should be possible in a more elegant way?
+          kconfig = pkgs.libsForQt5.kconfig;
+          kwidgetsaddons = pkgs.libsForQt5.kwidgetsaddons;
+          wrapQtAppsHook = pkgs.libsForQt5.wrapQtAppsHook;
+          kcoreaddons = pkgs.libsForQt5.kcoreaddons;
+          qtbase = pkgs.libsForQt5.qtbase;
+          mkDerivation = pkgs.stdenv.mkDerivation;
+          inherit (pkgs) cmake;
+        };
+      }
+    );
+}


### PR DESCRIPTION
With this PR, we add support for [Nix Flakes](https://nixos.wiki/wiki/Flakes), which significantly simplify using this project on systems that have Nix installed and (the currently experimental) flakes enabled.

## Nix Shell

Using flakes allows users to enter a nix shell with Koi available using a single command:

```bash
nix shell github:quoteme/koi?ref=nix-flake-support
```

Just type this into your shell and you already have Koi available. Exit the shell and Koi will be uninstalled with your next `nix-collect-garbage -d`. Simple as that!

## Nix Flake Input

With this PR, Koi can also be installed into a NixOS installation using a flake for system configuration by simply following the instructions under **Nix Flake installation** in the [README.md](https://github.com/Quoteme/Koi/blob/nix-flake-support/README.md#nixos-and-distros-with-nix). Setting up [NUR](https://nur.nix-community.org/) is no longer a requirement (but still works) :smile: .